### PR TITLE
Allowing replacement of specs

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -412,8 +412,17 @@ function addMethod(app, callback, spec) {
 
 // Set expressjs app handler
 
-function setAppHandler(app) {
+function setAppHandler(app, reset) {
   appHandler = app;
+
+  if (reset) {
+    resources = {};
+    validators = [];
+    appHandler = null;
+    allowedMethods = ['get', 'post', 'put', 'patch', 'delete'];
+    allowedDataTypes = ['string', 'integer', 'boolean', 'array'];
+    allModels = {};
+  }
 }
 
 // Change error handler

--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -418,7 +418,6 @@ function setAppHandler(app, reset) {
   if (reset) {
     resources = {};
     validators = [];
-    appHandler = null;
     allowedMethods = ['get', 'post', 'put', 'patch', 'delete'];
     allowedDataTypes = ['string', 'integer', 'boolean', 'array'];
     allModels = {};

--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -353,8 +353,6 @@ function addMethod(app, callback, spec) {
     });
   }
 
-  if (appendedToExistinApi) return;
-
   var api = {
     "path": spec.path
   };
@@ -374,7 +372,9 @@ function addMethod(app, callback, spec) {
   }
 
   root.apis.push(api);
-  appendToApi(root, api, spec);
+  if (!appendedToExistinApi) {
+    appendToApi(root, api, spec);
+  }
 
   //  convert .{format} to .json, make path params happy
   var fullPath = spec.path.replace(formatString, jsonSuffix).replace(/\/{/g, "/:").replace(/\}/g, "");

--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -348,7 +348,7 @@ function addMethod(app, callback, spec) {
         // add operation & return
         appendToApi(root, api, spec);
         appendedToExistinApi = true;
-        return;
+        return false;
       }
     });
   }


### PR DESCRIPTION
Fixed bug in addMethod to not look for method on api which doesn’t
exist. Returning from addMethod if replacing existing operation.
Replacing operation in array if matching method exists rather than
appending duplicate operations for the same method/path.