### PR TITLE
Allow to specify a custom API root path in the spec when adding resources

### DIFF
--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -403,7 +403,7 @@ Swagger.prototype.resourceListing = function(req, res) {
 
 Swagger.prototype.addMethod = function(app, callback, spec) {
   var self = this;
-  var apiRootPath = spec.apiRootPath || spec.path.split(/[\/\(]/)[1];
+  var apiRootPath = spec.resourcePath || spec.path.split(/[\/\(]/)[1];
   var root = self.resources[apiRootPath];
 
   if (root && root.apis) {

--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -661,7 +661,7 @@ function error(code, description) {
 // Stop express ressource with error code
 
 stopWithError = function(res, error) {
-  this.setHeaders(res);
+  Swagger.prototype.setHeaders(res);
   if (error && error.message && error.code)
     res.send(JSON.stringify(error), error.code);
   else

--- a/Common/node/swagger.js
+++ b/Common/node/swagger.js
@@ -403,7 +403,7 @@ Swagger.prototype.resourceListing = function(req, res) {
 
 Swagger.prototype.addMethod = function(app, callback, spec) {
   var self = this;
-  var apiRootPath = spec.path.split(/[\/\(]/)[1];
+  var apiRootPath = spec.apiRootPath || spec.path.split(/[\/\(]/)[1];
   var root = self.resources[apiRootPath];
 
   if (root && root.apis) {


### PR DESCRIPTION
Patch to allow to add a "resourcePath" property on spec sent to add method functions. If this property is set, it will override the default behavior, whit is to use the first part of the "path" porperty.

This allows the user to manually group resources in cases where only the path is not enough.