### PR TITLE
Refactor error/response handling

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -42,9 +42,9 @@ function Swagger() {
 
   // Default error handler
 
-  this.errorHandler = function (req, res, error) {
-    if (error.code && error.message)
-      res.send(JSON.stringify(error), error.code);
+  this.errorHandler = function (error, req, res, next) {
+    if (error.status && error.message)
+      res.send(JSON.stringify(error), error.status);
     else {
       console.error(req.method + " failed for path '" + require('url').parse(req.url).href + "': " + error);
       res.send(JSON.stringify({
@@ -411,24 +411,20 @@ Swagger.prototype.addMethod = function(app, callback, spec) {
 
       // todo: needs to do smarter matching against the defined paths
       var path = req.url.split('?')[0].replace(self.jsonSuffix, "").replace(/{.*\}/, "*");
-      if (!self.canAccessResource(req, path, req.method)) {
-        res.send(JSON.stringify({
-          "message": "forbidden",
-          "code": 403
-        }), 403);
-      } else {
-        try {
-          callback(req, res, next);
-        } catch (error) {
-          if (typeof self.errorHandler === "function") {
-            self.errorHandler(req, res, error);
-          } else if (self.errorHandler === "next") {
-            next(error);
-          } else {
-            throw error;
-          }
+      try {
+        if (!self.canAccessResource(req, path, req.method)) {
+          throw {
+          	message: 'Forbidden',
+          	status: 403
+          };
         }
-      }
+        callback(req, res, next);
+      } catch (error) {
+        if (typeof self.errorHandler === "function") {
+          return self.errorHandler(error, req, res, next);
+        }
+        return next(error);
+	  }
     });
   } else {
     console.error('unable to add ' + currentMethod.toUpperCase() + ' handler');
@@ -644,44 +640,29 @@ Swagger.prototype.setAuthorizations = function(data) {
 
 // Export most needed error types for easier handling
 Swagger.prototype.errors = {
-  'notFound': function (field, res) {
-    if (!res) {
-      return {
-        "code": 404,
-        "message": field + ' not found'
-      };
-    } else {
-      res.send({
-        "code": 404,
-        "message": field + ' not found'
-      }, 404);
-    }
+  'notFound': function (field, next) {
+  	var ret = {
+      "status": 404,
+      "message": field + ' not found'
+    };
+    if (typeof next == 'function') next(ret);
+    return ret;
   },
-  'invalid': function (field, res) {
-    if (!res) {
-      return {
-        "code": 400,
-        "message": 'invalid ' + field
-      };
-    } else {
-      res.send({
-        "code": 400,
-        "message": 'invalid ' + field
-      }, 404);
-    }
+  'invalid': function (field, next) {
+  	var ret = {
+      "status": 400,
+      "message": 'invalid ' + field
+    };
+    if (typeof next == 'function') next(ret);
+    return ret;
   },
-  'forbidden': function (res) {
-    if (!res) {
-      return {
-        "code": 403,
+  'forbidden': function (next) {
+  	var ret = {
+        "status": 403,
         "message": 'forbidden'
-      };
-    } else {
-      res.send({
-        "code": 403,
-        "message": 'forbidden'
-      }, 403);
-    }
+    };
+    if (typeof next == 'function') next(ret);
+    return ret;
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-node-express",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "author": {
     "name": "Tony Tam",
     "email": "fehguy@gmail.com",
@@ -41,7 +41,7 @@
   },
   "license": "apache 2.0",
   "scripts": {
-    "test": "mocha -r should './test/**/*.js'",
+    "test": "mocha -r should \"./test/**/*.js\"",
     "start": "node sample-application/app.js"
   }
 }

--- a/sample-application/resources.js
+++ b/sample-application/resources.js
@@ -26,7 +26,7 @@ exports.findById = {
     var pet = petData.getPetById(id);
 
     if(pet) res.send(JSON.stringify(pet));
-    else throw swe.notFound('pet',res);
+    else throw swe.notFound('pet');
   }
 };
 


### PR DESCRIPTION
Refactor error handling to better match node/express convention, and make it easier to override/adapt response behavior.  All error responses are now done through the error handler instead of directly.  The error handler's signature now matches the express error signature, as well as deferring to the default handler if the errorHandler is not a method.

Notes: 
* The property of `.status` seems to be the prevalent convention for the https status of the response, over `.code`.
* These are breaking changes, but I feel necessary to offer a better and more consistent experience with the rest of node and express with this module.