### PR TITLE
Fix regression in addModels method

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -491,7 +491,7 @@ Swagger.prototype.addPatch = Swagger.prototype.addPATCH = function() {
 // adds models to swagger
 
 Swagger.prototype.addModels = function(models) {
-  models = _.cloneDeep(models).models;
+  models = _.cloneDeep(models);
   var self = this;
   if (!self.allModels) {
     self.allModels = models;

--- a/test/swagger.tests.js
+++ b/test/swagger.tests.js
@@ -1,7 +1,39 @@
 'use strict';
+var assert = require('assert');
 
-describe('swagger', function(){
-  it('should be a module', function(){
-    require('../');
-  });  
+describe('swagger', function () {
+	it('should be a module', function () {
+		require('../');
+	});
+
+	describe('addModels', function () {
+		it('should accept a hash and add all the top level members', function () {
+			var instance = require('../');
+
+			// Add some models.
+			instance.addModels({
+				'One': {
+					id: 'One',
+					description: 'The first model.'
+				},
+				'Two': {
+					id: 'Two',
+					description: 'The second model.'
+				}
+			});
+
+			// And add some more to test merging with the above.
+			instance.addModels({
+				'Three': {
+					id: 'Three',
+					description: 'The third model.'
+				}
+			});
+
+			// Note, there is no good API to test this worked so we have to check the innards of the class itself.
+			assert.equal(instance.allModels['One'].id, 'One');
+			assert.equal(instance.allModels['Two'].id, 'Two');
+			assert.equal(instance.allModels['Three'].id, 'Three');
+		});
+	});
 });


### PR DESCRIPTION
Removed `.model` property accidentally added in a previous commit.
Fixes #129

Note that we probably need to clean up the README and the example model file in this regard. I can do that in a new PR if this one is ok.