### PR TITLE
Update swagger.js

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -508,7 +508,10 @@ Swagger.prototype.addPatch = Swagger.prototype.addPATCH = function() {
 // adds models to swagger
 
 Swagger.prototype.addModels = function(models) {
-  models = _.cloneDeep(models).models;
+  
+  // Swagger UI does not show Response Class if this line is uncommented
+  // models = _.cloneDeep(models).models;
+  
   var self = this;
   if (!self.allModels) {
     self.allModels = models;


### PR DESCRIPTION
Swagger UI does not show Response Class if this line is uncommented.
Maybe there are side effects of this change.
After commenting this line all my models are showing on the swagger-ui interface.