### PR TITLE
regex parameter routing based on type

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -363,6 +363,19 @@ Swagger.prototype.resourceListing = function(req, res) {
   res.end();
 };
 
+Swagger.prototype.getParameterRegex = function(parameter) {
+  var type = parameter.type;
+  if (type === 'integer' || type === 'long') {
+    return '\\d+';
+  }
+  if (type === 'float' || type === 'double') {
+    return '\\d+\\.?\\d+?';
+  }
+  if (type === 'boolean') {
+    return '(1|0|true|false|on|off)';
+  }
+};
+
 // Adds a method to the api along with a spec.  If the spec fails to validate, it won't be added
 
 Swagger.prototype.addMethod = function(app, callback, spec) {
@@ -404,7 +417,22 @@ Swagger.prototype.addMethod = function(app, callback, spec) {
   appendToApi(root, api, spec);
 
   //  convert .{format} to .json, make path params happy
-  var fullPath = spec.path.replace(self.formatString, self.jsonSuffix).replace(/\/{/g, '/:').replace(/\}/g, '');
+  var fullPath = spec.path.replace(self.formatString, self.jsonSuffix);
+
+  // replace {name} with :name or :name(regex)
+  fullPath = fullPath.replace(/\{([^\}]+)\}/g, function(match, name) {
+    var regex;
+    if (spec.parameters) {
+      var parameter = spec.parameters.filter(function(param) {
+        return param.name === name;
+      })[0];
+      if (parameter) {
+        regex = self.getParameterRegex(parameter);
+      }
+    }
+    return ':' + name + (regex ? '('+ regex.toString() +')' : '');
+  });
+
   var currentMethod = spec.method.toLowerCase();
   if (allowedMethods.indexOf(currentMethod) > -1) {
     app[currentMethod](fullPath, function (req, res, next) {


### PR DESCRIPTION
this will detect certain parameter types in path, and use a relevant routing regex based on the parameter type.
more types can be added later (eg. date, dateTime)

example:

``` js
// on spec
{
    parameters: [
      swagger.pathParam('id', 'ID of Pet that needs to be fetched', 'integer')
    ]
}
```

express route added, before `/pet/:id`, after: `/pet/:id(\d+)`

this allows someone to use a route like `/pet/most-popular` 