### PR TITLE
JSONSchema v4 allowes to define pattern properties.

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -164,6 +164,7 @@ Swagger.prototype.addPropertiesToRequiredModels = function(properties, requiredM
           if (ref && requiredModels.indexOf(ref) < 0) {
             requiredModels.push(ref);
             self.addPropertiesToRequiredModels(self.allModels[ref].properties, requiredModels);
+            self.addPropertiesToRequiredModels(self.allModels[ref].patternProperties, requiredModels);
           }
         }
         break;
@@ -181,10 +182,14 @@ Swagger.prototype.addPropertiesToRequiredModels = function(properties, requiredM
       if (property.$ref){
         requiredModels.push(property.$ref);
         self.addPropertiesToRequiredModels(self.allModels[property.$ref].properties, requiredModels);
+        self.addPropertiesToRequiredModels(self.allModels[property.$ref].patternProperties, requiredModels);
       }
     }
     if (property.properties) {
       self.addPropertiesToRequiredModels(property.properties, requiredModels);
+    }
+    if (property.patternProperties) {
+      self.addPropertiesToRequiredModels(property.patternProperties, requiredModels);
     }
   });
 };
@@ -271,6 +276,9 @@ Swagger.prototype.filterApiListing = function(req, res, r) {
   _.forOwn(output.models, function (model) {
     if (model && model.properties) {
       self.addPropertiesToRequiredModels(model.properties, requiredModels);
+    }
+    if (model && model.patternProperties) {
+      self.addPropertiesToRequiredModels(model.patternProperties, requiredModels);
     }
   });
   _.forOwn(requiredModels, function (modelName) {


### PR DESCRIPTION
JSONSchema v4 allowes to define pattern properties, adding handling of those, so the $ref model is present in json api docs.

See http://json-schema.org/example2.html