### PR TITLE
Issue #181 README was showing deprecated example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Using NPM, include the `swagger-node-express` module in your `package.json` depe
 ```js
 // Load module dependencies.
 var express = require("express")
- , url = require("url")
- , swagger = require("swagger-node-express");
+ , url = require("url");
 
 // Create the application.
 var app = express();
@@ -43,7 +42,7 @@ app.use(express.json());
 app.use(express.urlencoded());
 
 // Couple the application to the Swagger module.
-swagger.setAppHandler(app);
+var swagger = require("swagger-node-express").createNew(app);
 ```
 
 You can optionally add a validator function, which is used to filter the swagger json and request operations:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ var findById = {
     "notes" : "Returns a pet based on ID",
     "summary" : "Find pet by ID",
     "method": "GET",
-    "parameters" : [swagger.pathParam("petId", "ID of pet that needs to be fetched", "string")],
+    "parameters" : [swagger.paramTypes.path("petId", "ID of pet that needs to be fetched", "string")],
     "type" : "Pet",
     "errorResponses" : [swagger.errors.invalid('id'), swagger.errors.notFound('pet')],
     "nickname" : "getPetById"


### PR DESCRIPTION
From https://github.com/swagger-api/swagger-node-express/pull/182.

Since this didn't seem to be moving and the example in the README is still showing the deprecated setAppHandler, I submit this.