### PR TITLE
Replaced errorResponses with responseMessages

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ var findById = {
     "method": "GET",
     "parameters" : [swagger.paramTypes.path("petId", "ID of pet that needs to be fetched", "string")],
     "type" : "Pet",
-    "errorResponses" : [swagger.errors.invalid('id'), swagger.errors.notFound('pet')],
+    "responseMessages" : [swagger.errors.invalid('id'), swagger.errors.notFound('pet')],
     "nickname" : "getPetById"
   },
   'action': function (req,res) {


### PR DESCRIPTION
I could not find errorResponses in the 1.2 spec, and the swagger.errors provide the property `code` and `message`. I think it used to be `reason` and I can see code in this repo that tries to deal with errorResponses, however when using swagger-ui, the message is not displayed.