### PR TITLE
Parsing of List[customObject] added when resolving required models

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -261,7 +261,7 @@ Swagger.prototype.filterApiListing = function(req, res, r) {
   // add required models to output
   output.models = {};
   _.forOwn(requiredModels, function (modelName) {
-    var model = self.allModels[modelName];
+    var model = self.allModels[modelName.replace(/^List\[(.+?)]/,'$1')];
     if (model) {
       output.models[modelName] = model;
     }

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -263,7 +263,7 @@ Swagger.prototype.filterApiListing = function(req, res, r) {
   _.forOwn(requiredModels, function (modelName) {
     var model = self.allModels[modelName.replace(/^List\[(.+?)]/,'$1')];
     if (model) {
-      output.models[modelName] = model;
+      output.models[modelName.replace(/^List\[(.+?)]/,'$1')] = model;
     }
   });
 


### PR DESCRIPTION
When there's only one operation that return type is someModel but as List[someModel] not a single object, then that model won't be exported to the output models.